### PR TITLE
Tweak mapping mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,14 @@ Here are code snippets for some common installation methods (use only one):
   -- `prefix` defines keys mapped during `setup()`: in Normal mode
   -- to operate on textobject and line, in Visual - on selection.
 
+  -- `selection` can be set to define a different mapping in Visual mode.
+  -- If `nil` (default), Visual mode mapping will be same as `prefix`.
+  -- Set as an empty string to disable Visual mode mapping.
+
   -- Evaluate text and replace with output
   evaluate = {
     prefix = 'g=',
+    selection = nil,
 
     -- Function which does the evaluation
     func = nil,
@@ -159,6 +164,7 @@ Here are code snippets for some common installation methods (use only one):
   -- Exchange text regions
   exchange = {
     prefix = 'gx',
+    selection = nil,
 
     -- Whether to reindent new text to match previous indent
     reindent_linewise = true,
@@ -167,6 +173,7 @@ Here are code snippets for some common installation methods (use only one):
   -- Multiply (duplicate) text
   multiply = {
     prefix = 'gm',
+    selection = nil,
 
     -- Function which can modify text before multiplying
     func = nil,
@@ -175,6 +182,7 @@ Here are code snippets for some common installation methods (use only one):
   -- Replace text with register
   replace = {
     prefix = 'gr',
+    selection = nil,
 
     -- Whether to reindent new text to match previous indent
     reindent_linewise = true,
@@ -183,6 +191,7 @@ Here are code snippets for some common installation methods (use only one):
   -- Sort text
   sort = {
     prefix = 'gs',
+    selection = nil,
 
     -- Function which does the sort
     func = nil,

--- a/doc/mini-operators.txt
+++ b/doc/mini-operators.txt
@@ -118,7 +118,10 @@ For each operator the following mappings are created:
 - In Normal mode to operate on line. Appends to `prefix` the last character.
   This aligns with |operator-doubled| and established patterns for operators
   with more than two characters, like |guu|, |gUU|, etc.
-- In Visual mode to operate on visual selection. Uses `prefix` directly.
+- In Visual mode to operate on visual selection. Uses `prefix` directly, if
+  `selection` is `nil` (default). Set `selection` to a string to choose a
+  different mapping for Visual mode, or an empty string to disable Visual
+  mode mapping.
 
 Example of default mappings for "replace":
 - `gr` in Normal mode for operating on textobject.
@@ -130,23 +133,26 @@ Example of default mappings for "replace":
 
 There are two suggested ways to customize mappings:
 
-- Change `prefix` in |MiniOperators.setup()| call. For example, doing >lua
+- Change `prefix` in |MiniOperators.setup()| call. Here's an example to
+  change the "exchange" operator's mappings to 'tommcdo/vim-exchange' style: >lua
 
-    require('mini.operators').setup({ replace = { prefix = 'cr' } })
+    require('mini.operators').setup(
+      { exchange = { prefix = 'cx', selection = 'X' } }
+    )
 <
-  will make mappings for `cr` / `crr` / `cr` instead of `gr` / `grr` / `gr`.
+  This will make mappings for `cx` / `cxx` / `X` instead of `gx` / `gxx` / `gx`.
 
-- Disable automated mapping creation by supplying empty string as prefix and
+- Or, disable automated mapping creation by supplying empty string as prefix and
   use |MiniOperators.make_mappings()| directly. For example: >lua
 
     -- Disable automated creation of "replace"
     local operators = require('mini.operators')
-    operators.setup({ replace = { prefix = '' } })
+    operators.setup({ exchange = { prefix = '' } })
 
     -- Make custom mappings
     operators.make_mappings(
-      'replace',
-      { textobject = 'cr', line = 'crr', selection = 'cr' }
+      'exchange',
+      { textobject = 'cx', line = 'cxx', selection = 'X' }
     )
 <
 ------------------------------------------------------------------------------
@@ -175,9 +181,14 @@ Default values:
     -- `prefix` defines keys mapped during `setup()`: in Normal mode
     -- to operate on textobject and line, in Visual - on selection.
 
+    -- `selection` can be set to define a different mapping in Visual mode.
+    -- If `nil` (default), Visual mode mapping will be same as `prefix`.
+    -- Set as an empty string to disable Visual mode mapping.
+
     -- Evaluate text and replace with output
     evaluate = {
       prefix = 'g=',
+      selection = nil,
 
       -- Function which does the evaluation
       func = nil,
@@ -186,6 +197,7 @@ Default values:
     -- Exchange text regions
     exchange = {
       prefix = 'gx',
+      selection = nil,
 
       -- Whether to reindent new text to match previous indent
       reindent_linewise = true,
@@ -194,6 +206,7 @@ Default values:
     -- Multiply (duplicate) text
     multiply = {
       prefix = 'gm',
+      selection = nil,
 
       -- Function which can modify text before multiplying
       func = nil,
@@ -202,6 +215,7 @@ Default values:
     -- Replace text with register
     replace = {
       prefix = 'gr',
+      selection = nil,
 
       -- Whether to reindent new text to match previous indent
       reindent_linewise = true,
@@ -210,6 +224,7 @@ Default values:
     -- Sort text
     sort = {
       prefix = 'gs',
+      selection = nil,
 
       -- Function which does the sort
       func = nil,
@@ -220,6 +235,10 @@ Default values:
 
 `evaluate.prefix` is a string used to automatically infer operator mappings keys
 during |MiniOperators.setup()|. See |MiniOperators-mappings|.
+
+`evaluate.selection` is a string used to choose a separate mapping for
+Visual mode, or to disable Visual mode mapping for operator.
+If `nil` (default), Visual mode mapping is set as `evaluate.prefix`.
 
 `evaluate.func` is a function used to actually evaluate text region.
 If `nil` (default), |MiniOperators.default_evaluate_func()| is used.
@@ -237,6 +256,10 @@ config (`vim.b.minioperators_config`; see |mini.nvim-buffer-local-config|).
 `exchange.prefix` is a string used to automatically infer operator mappings keys
 during |MiniOperators.setup()|. See |MiniOperators-mappings|.
 
+`exchange.selection` is a string used to choose a separate mapping for
+Visual mode, or to disable Visual mode mapping for operator.
+If `nil` (default), Visual mode mapping is set as `exchange.prefix`.
+
 Note: default value "gx" overrides |netrw-gx| and |gx| / |v_gx|. If you prefer
 using its original functionality, choose different `config.prefix`.
 
@@ -249,6 +272,10 @@ regions are exchanged preserving their indents; if `true` - without them.
 `multiply.prefix` is a string used to automatically infer operator mappings keys
 during |MiniOperators.setup()|. See |MiniOperators-mappings|.
 
+`multiply.selection` is a string used to choose a separate mapping for
+Visual mode, or to disable Visual mode mapping for operator.
+If `nil` (default), Visual mode mapping is set as `multiply.prefix`.
+
 `multiply.func` is a function used to optionally update multiplied text.
 If `nil` (default), text used as is.
 
@@ -260,6 +287,10 @@ array of lines as output.
 `replace.prefix` is a string used to automatically infer operator mappings keys
 during |MiniOperators.setup()|. See |MiniOperators-mappings|.
 
+`replace.selection` is a string used to choose a separate mapping for
+Visual mode, or to disable Visual mode mapping for operator.
+If `nil` (default), Visual mode mapping is set as `replace.prefix`.
+
 `replace.reindent_linewise` is a boolean indicating whether newly put linewise
 text should preserve indent of replaced text.
 
@@ -267,6 +298,10 @@ text should preserve indent of replaced text.
 
 `sort.prefix` is a string used to automatically infer operator mappings keys
 during |MiniOperators.setup()|. See |MiniOperators-mappings|.
+
+`sort.selection` is a string used to choose a separate mapping for
+Visual mode, or to disable Visual mode mapping for operator.
+If `nil` (default), Visual mode mapping is set as `sort.prefix`.
 
 `sort.func` is a function used to actually sort text region.
 If `nil` (default), |MiniOperators.default_sort_func()| is used.

--- a/lua/mini/operators.lua
+++ b/lua/mini/operators.lua
@@ -586,10 +586,21 @@ MiniOperators.make_mappings = function(operator_name, lhs_tbl)
   local expr_opts = { expr = true, replace_keycodes = false, desc = operator_desc .. ' operator' }
   H.map('n', lhs_tbl.textobject, string.format('v:lua.MiniOperators.%s()', operator_name), expr_opts)
 
-  local rhs = lhs_tbl.textobject .. '_'
   -- - Make `sort()` line mapping to be charwise
-  if operator_name == 'sort' then rhs = '^' .. lhs_tbl.textobject .. 'g_' end
-  H.map('n', lhs_tbl.line, rhs, { remap = true, desc = operator_desc .. ' line' })
+  if operator_name == 'sort' then
+    H.map('n', lhs_tbl.line, function()
+      local count = vim.v.count > 0 and vim.v.count or ""
+      vim.api.nvim_feedkeys("^", "n", false)
+      vim.api.nvim_feedkeys(count .. lhs_tbl.textobject, "m", false)
+      vim.api.nvim_feedkeys("g_", "n", false)
+    end, { remap = true, desc = operator_desc .. ' line' })
+  else
+    H.map('n', lhs_tbl.line, function()
+      local count = vim.v.count > 0 and vim.v.count or ""
+      vim.api.nvim_feedkeys(count .. lhs_tbl.textobject, "m", false)
+      vim.api.nvim_feedkeys("_", "n", false)
+    end, { remap = true, desc = operator_desc .. ' line' })
+  end
 
   local visual_rhs = string.format([[<Cmd>lua MiniOperators.%s('visual')<CR>]], operator_name)
   H.map('x', lhs_tbl.selection, visual_rhs, { desc = operator_desc .. ' selection' })


### PR DESCRIPTION
#2

- [x] Take `selection` mapping from config
  - Problem: how to allow not specifying `selection`, and setting that the same as `prefix`, while still allowing to disable visual mode mapping?
    - Could have 3 states:
      1. string
      2. empty string
      3. nil
  - [x] Update docs
    - [x] Find out how helpfiles are generated from the comments in the lua file
    - https://github.com/echasnovski/mini.doc
    - `:lua require("mini.doc").setup()`
    - `:lua MiniDoc.generate()`
    - (creates `./doc/mini.txt`)
      - remove top 'border'
      - [`chompeof`](https://salferrarello.com/remove-newline-at-end-of-text-file/)
- [x] Fix line mappings with custom operator-pending `_` remap
  - Try feedkeys with `n` opt ("do not remap")
  - Only worked like:
    - `nmap dpp <cmd>call feedkeys("dp")<cr><cmd>call feedkeys("_", "n")`, *but* now for example count doesn't work
      - Solution: add count from `vim.v.count` inside the `feedkeys`